### PR TITLE
Fixed git-pretty-stat with older versions of Ubuntu(-Server)

### DIFF
--- a/src/GitPrettyStats/Repository.php
+++ b/src/GitPrettyStats/Repository.php
@@ -82,7 +82,7 @@ class Repository
      */
     public function countCommitsFromGit ()
     {
-        return $this->getClient()->run($this->gitter, 'rev-list --count HEAD');
+        return $this->getClient()->run($this->gitter, 'rev-list HEAD | wc -l | tr -d "\n"');
     }
 
     /**


### PR DESCRIPTION
Work around the fact, that the --count option is missing in older versions of git rev-list.

Well this is not pretty, but I still hope that you will merge this request, because this would allow Ubuntu Server Users like me to use your great software. I would like to avoid using a custom build git (on my server) because I have other services running on this server which also require git (e.g. a gitolite).

I tested this on a VPS (sadly I can only install CentOS or Ubuntu) and it works great.

Cheers
Daniel Reuter
